### PR TITLE
Allow progression after incorrect Practice answers

### DIFF
--- a/src/pages/GrammarPracticePage.tsx
+++ b/src/pages/GrammarPracticePage.tsx
@@ -204,7 +204,7 @@ function GrammarPracticePage({
   const showMakeResultPanel = isMakeStep && isAnswered && (isCorrectAnswer || isWrongAnswer)
   const makeResultImage = isCorrectAnswer ? choiceCorrectImage : choiceWrongImage
   const canMoveToNextPracticeStep =
-    isCorrectAnswer && !checkAnswer.isPending && (!isChoiceStep || showChoiceFeedbackPanel)
+    isAnswered && !checkAnswer.isPending && (!isChoiceStep || showChoiceFeedbackPanel)
 
   const readingQuestions = [
     {


### PR DESCRIPTION
## Summary

- Enable progression after any non-empty submitted Practice answer.
- Preserve pending answer checks and multiple-choice feedback timing.
- Apply the behavior to choice, fill-in, and sentence-building steps.

## Validation

- npm run build
- npm run lint

Closes #1